### PR TITLE
Playbook名の変更

### DIFF
--- a/SmartCSxALAXALA/3.1-initial_setup_the_alaxala_device_via_smartcs.md
+++ b/SmartCSxALAXALA/3.1-initial_setup_the_alaxala_device_via_smartcs.md
@@ -182,7 +182,7 @@ login:
 
 <br>
 
-■Playbook(initial-setting_step1_user.yml)
+■Playbook(initial_setting_v1_user.yml)
 ```yaml
 ---
 - name: user settings from console using SartCS
@@ -243,7 +243,7 @@ login:
 
 ■実行例
 ```
-$ ansible-playbook initial-setting_step1_user.yml 
+$ ansible-playbook initial_setting_v1_user.yml 
 ```
 
 
@@ -319,7 +319,7 @@ login:
 
 <br>
 
-■Playbook(initial-setting_step2_ansible-reach.yml )
+■Playbook(initial_setting_v2_ansible_reach.yml )
 ```yaml
 ---
 - name: ansible-reach settings from console using SmartCS
@@ -387,7 +387,7 @@ Playbook内容（モジュールオプション）の説明
 
 ■実行例
 ```
-$ ansible-playbook initial-setting_step2_ansible-reach.yml
+$ ansible-playbook initial_setting_v2_ansible_reach.yml
 ```
 
 


### PR DESCRIPTION
- WSにおけるStepと、init系PlaybookのStepが重複する上番号がずれていたので、Playbook側をv1と変更
- Playbook名に - と _ が両方使われていたので_に統一。