### PR TITLE
3.4 環境情報へのリンク追加

### DIFF
--- a/SmartCSxALAXALA/3.4-setting_of_alaxala_device_via_smartcs.md
+++ b/SmartCSxALAXALA/3.4-setting_of_alaxala_device_via_smartcs.md
@@ -33,7 +33,7 @@
 
 | vars | Playbook例の値 | 備考 | 
 |:---|:---|:---|
-| tty_no |'1' | ユーザ毎に割り当てられているSmartCSの**tty**番号を指定します |
+| tty_no |'1' | ユーザ毎に割り当てられているSmartCSの[**tty**番号](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
 
 <br>
 
@@ -133,9 +133,9 @@ Playbookは以下のような内容となります。
 
 |vars |Playbook例の値 |備考 | 
 |:---|:---|:---|
-|ansible_user |'port01' |SmartCSの**ポートユーザ ID**を指定します |
-|ansible_password |'secret01' |SmartCSの**ポートユーザ Password**を指定します |
-|ansible_port |9301 |SmartCSの**Ansibleアクセス用 TCPポート**を指定します |
+|ansible_user |'port01' |SmartCSの[**ポートユーザ ID**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
+|ansible_password |'secret01' |SmartCSの[**ポートユーザ Password**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
+|ansible_port |9301 |SmartCSの[**(Ansibleアクセス用) 拡張ユーザー TCPポート**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
 
 <br>
 
@@ -184,13 +184,13 @@ Playbookは以下のような内容となります。
 SmartCS経由で接続を行うため、接続先をsmartcsと設定します。  
 - <code>ansible_user: port01</code>  
 SmartCS経由で接続を行うため、ログインユーザを設定します。 
-ユーザごとに異なりますので、Playbook作成時にvarsに記載のansible_userの値を変更してください。 
+ユーザごとに異なりますので、[環境情報](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を参考にしてPlaybook作成時にvarsに記載のansible_userの値を変更してください。 
 - <code>ansible_password: secret01</code>  
 SmartCS経由で接続を行うため、ログインユーザのパスワードを設定します。  
-ユーザごとに異なりますので、Playbook作成時にvarsに記載のansible_passwordの値を変更してください。 
+ユーザごとに異なりますので、[環境情報](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を参考にしてPlaybook作成時にvarsに記載のansible_passwordの値を変更してください。 
 - <code>ansible_port: 9301</code>  
 SmartCS経由で接続を行うため、ポート番号を指定します。  
-ユーザごとに異なりますので、Playbook作成時にvarsに記載のansible_portの値を変更してください。 
+ユーザごとに異なりますので、[環境情報](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を参考にしてPlaybook作成時にvarsに記載のansible_portの値を変更してください。 
 - <code>ansible_connection: network_cli</code>  
 SmartCS経由でコンソールアクセスを行う場合、コネクションプラグインとして<code>network_cli</code>をサポートしている必要があります。
 


### PR DESCRIPTION
環境情報のリンクを追加
Ansibleアクセス用TCPポートの名称に、環境情報と合わせる目的で拡張ユーザーの文言を追加。
※参加者が混乱しないよう、統一されていることが大事なので、任意の名称に揃えてあれば問題ありません。