### PR TITLE
4.1の環境情報にリンクを追加

### DIFF
--- a/SmartCSxALAXALA/4.1-automation_of_operation_error_recovery.md
+++ b/SmartCSxALAXALA/4.1-automation_of_operation_error_recovery.md
@@ -42,7 +42,7 @@ STEP1では、ALAXALA装置に対してアクセスリストの設定を行い�
 
 | vars | Playbook例の値 | 備考 | 
 |:---|:---|:---|
-| RHEL_IP | '192.168.127.2' | ユーザ毎に割り当てられている **RHEL IP**を指定します |
+| rhel_ipaddr | '192.168.127.2' | ユーザ毎に割り当てられている [**RHEL IP**](./1.1-preparing_for_the_exercise.md#rhel--ansible-controller-)を指定します |
 
 <br>
 
@@ -55,11 +55,12 @@ STEP1では、ALAXALA装置に対してアクセスリストの設定を行い�
   
   vars:
   ### Variables that NEED to Change ###
-  - RHEL_IP: '192.168.127.2'
+  - rhel_ipaddr: '192.168.127.2'
   
   ### Variables that should NOT change ###
   - ansible_connection: network_cli
   - ansible_network_os: ax
+  
   - ansible_become: yes
   - ansible_become_method: enable
   - ansible_become_pass: 'secret2230'
@@ -68,7 +69,7 @@ STEP1では、ALAXALA装置に対してアクセスリストの設定を行い�
   - name: configure access list
     ax_config:
       lines:
-        - 10 permit host {{ RHEL_IP }}
+        - 10 permit host {{ rhel_ipaddr }}
         - 20 deny any
       parents: ip access-list standard "access ansible host only"
       save_when: changed
@@ -84,7 +85,7 @@ STEP1では、ALAXALA装置に対してアクセスリストの設定を行い�
 ■Playbook内容の説明  
 <configre access list>
 <code>"access ansible host only"</code>というアクセスリストのグループを作成し、接続を許可するIPホストを定義します。  
-Ansibleホスト以外からの接続を受け付けない設定を投入しています。
+[Ansibleホスト]((./1.1-preparing_for_the_exercise.md#rhel--ansible-controller-))以外からの接続を受け付けない設定を投入しています。
   
 <set access-list to intarface>
 作成したアクセスリストのグループ<code>"access ansible host only"</code>をインターフェース（<code>vlan 1</code>）に設定しています。
@@ -210,9 +211,9 @@ $ cp ../exercise_3/console_logout.yml .
 
 | vars | Playbook例の値 | 備考 | 
 |:---|:---|:---|
-| ansible_user | 'port01' | SmartCSの**ポートユーザ ID**を指定します |
-| ansible_password | 'secret01' | SmartCSの**ポートユーザ Password**を指定します |
-| ansible_port | 9301 | SmartCSの**Ansibleアクセス用 TCPポート**を指定します |
+| ansible_user | 'port01' | SmartCSの[**ポートユーザ ID**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
+| ansible_password | 'secret01' | SmartCSの[**ポートユーザ Password**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
+| ansible_port | 9301 | SmartCSの[**(Ansibleアクセス用) 拡張ユーザ TCPポート**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
 
 <br>
 
@@ -232,6 +233,7 @@ $ cp ../exercise_3/console_logout.yml .
   ### Variables that should NOT change ###
   - ansible_connection: network_cli
   - ansible_network_os: ax
+  
   - ansible_become: yes
   - ansible_become_method: enable
   - ansible_become_pass: 'secret2230'
@@ -314,10 +316,10 @@ add_acl.ymlとの差分
 
 | vars | Playbook例の値 | 備考 | 
 |:---|:---|:---|
-| ansible_user | 'port01' | SmartCSの**ポートユーザ ID**を指定します |
-| ansible_password | 'secret01' | SmartCSの**ポートユーザ Password**を指定します |
-| ansible_port | 9301 | SmartCSの**Ansibleアクセス用 TCPポート**を指定します |
-| RHEL_IP | '192.168.127.2' | ユーザ毎に割り当てられている **RHEL IP**を指定します |
+| ansible_user | 'port01' | SmartCSの[**ポートユーザ ID**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
+| ansible_password | 'secret01' | SmartCSの[**ポートユーザ Password**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
+| ansible_port | 9301 | SmartCSの[**(Ansibleアクセス用) 拡張ユーザ TCPポート**](./1.1-preparing_for_the_exercise.md#コンソールサーバ--smartcs-)を指定します |
+| rhel_ipaddr | '192.168.127.2' | ユーザ毎に割り当てられている [**RHEL IP**](./1.1-preparing_for_the_exercise.md#rhel--ansible-controller-)を指定します |
 
 <br>
 
@@ -334,11 +336,13 @@ add_acl.ymlとの差分
   - ansible_user: "port01"
   - ansible_password: "secret01"
   - ansible_port: 9301
-  - RHEL_IP: '192.168.127.2'
+  
+  - rhel_ipaddr: '192.168.127.2'
   
   ### Variables that should NOT change ###
   - ansible_connection: network_cli
   - ansible_network_os: ax
+  
   - ansible_become: yes
   - ansible_become_method: enable
   - ansible_become_pass: 'secret2230'
@@ -347,7 +351,7 @@ add_acl.ymlとの差分
   - name: configure access list
     ax_config:
       lines:
-        - 10 permit host {{ RHEL_IP }}
+        - 10 permit host {{ rhel_ipaddr }}
         - 20 deny any
       parents: ip access-list standard "access ansible host only"
       save_when: changed


### PR DESCRIPTION
- 環境情報のリンクを追加
- 変数名を変更（大文字を除外&他の形式と合わせる）
- Ansibleアクセス用 TCPポートの名称を、環境情報に合わせて編集